### PR TITLE
Support middleware func is createStore

### DIFF
--- a/src/lib/createStore.js
+++ b/src/lib/createStore.js
@@ -17,9 +17,9 @@ export default function (client, customRequire, customMiddleware, hotCallback, d
     middleware.push(require("redux-immutable-state-invariant")());
   }
 
-  // When `customMiddleware` is of type `function`, pass it a shallow
-  // copy of the current array of `middlewares` and expect a new value
-  // in return. Fallback to default behaviour.
+  // When `customMiddleware` is of type `function`, pass it current
+  // array of `middlewares` and expect a new value in return.
+  // Fallback to default behaviour.
   middleware = typeof customMiddleware === 'function'
     ? customMiddleware([...middleware])
     : middleware.concat(customMiddleware);

--- a/src/lib/createStore.js
+++ b/src/lib/createStore.js
@@ -3,14 +3,6 @@ import { combineReducers, createStore, applyMiddleware, compose } from "redux";
 import _gluestick from "./reducers";
 import promiseMiddleware from "../lib/promiseMiddleware";
 
-const getMiddlewares = (middlewares, customMiddlewares) => {
-  if (typeof customMiddlewares === 'function') {
-    return customMiddlewares(middlewares);
-  }
-
-  return middlewares.concat(customMiddlewares);
-};
-
 export default function (client, customRequire, customMiddleware, hotCallback, devMode) {
   const reducer = combineReducers(Object.assign({}, {_gluestick}, customRequire()));
 

--- a/src/lib/createStore.js
+++ b/src/lib/createStore.js
@@ -20,11 +20,9 @@ export default function (client, customRequire, customMiddleware, hotCallback, d
   // When `customMiddleware` is of type `function`, pass it a shallow
   // copy of the current array of `middlewares` and expect a new value
   // in return. Fallback to default behaviour.
-  if (typeof customMiddleware === 'function') {
-    middleware = customMiddleware([...middleware]);
-  } else {
-    middleware.concat(customMiddleware);
-  }
+  middleware = typeof customMiddleware === 'function'
+    ? customMiddleware([...middleware])
+    : middleware.concat(customMiddleware);
 
   const composeArgs = [
     applyMiddleware.apply(this, middleware),


### PR DESCRIPTION
Fixes https://github.com/TrueCar/gluestick/issues/412

Adds support for `customMiddleware` to be a function and receive the most up to date array of middlewares (injected by default by gluestick)